### PR TITLE
Fixing linking flag `-lpthread` -> `-pthread` so linking works under Linux Mint 17.2

### DIFF
--- a/bobcat/INSTALL.im
+++ b/bobcat/INSTALL.im
@@ -31,7 +31,7 @@
 
     // Specify linker options that should be used when creating the shared
     // library
-#define LDFLAGS    "-lpthread"
+#define LDFLAGS    "-pthread"
 
     // The following /bin/cp options are used to keep, rather than follow
     // symbolic references. If your installation doesn't support these flags,


### PR DESCRIPTION
I had problems with the compilation process. To be more exact, I encountered the following error:

```
$ ./build light strip
mkdir -p tmp/liba tmp/bobcat/ tmp/libso

Creating shared library libbobcat.so
g++ --std=c++14 -O2 -Wall -fdiagnostics-color=never -isystem tmp -fPIC -lpthread -shared -Wl,--as-needed,-z,defs,-soname,libbobcat.so.4 -o tmp/libso/libbobcat.so.4.04.00 */os/*.o 
process/os/60start2.o: In function `FBB::Process::start(FBB::ProcessEnums::IOMode, FBB::Process::ProcessType, unsigned long, unsigned long)':
start2.cc:(.text+0xda): undefined reference to `pthread_create'
sharedcondition/os/71condition1.o: In function `FBB::SharedCondition::Condition::Condition()':
condition1.cc:(.text+0x2f): undefined reference to `pthread_condattr_setpshared'
sharedmutex/os/73sharedmutex1.o: In function `FBB::SharedMutex::SharedMutex()':
sharedmutex1.cc:(.text+0x1d): undefined reference to `pthread_mutexattr_init'
sharedmutex1.cc:(.text+0x2a): undefined reference to `pthread_mutexattr_setpshared'
collect2: error: ld returned 1 exit status
Fatal: system - failure of system call (status 256)
```

After trying out some different things, I changed the `-lpthread` flag to `-pthread`. This works, at least on my architecture (Linux Mint 17.2, kernel: x86_64 Linux 3.16.0-38-generic). I expect this to work on other systems as well (But of course, please do test). See more information about the difference between the two flags here: http://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling#23251828

:slightly_smiling_face: 

~Wiebe-Marten